### PR TITLE
fixes invocation of `configureHost` nami ghost module method

### DIFF
--- a/0/rootfs/run.sh
+++ b/0/rootfs/run.sh
@@ -7,4 +7,7 @@ USER=ghost
 export NODE_ENV=production
 
 info "Starting ghost..."
-exec gosu ${USER} /opt/bitnami/ghost/node_modules/pm2/bin/pm2 start --no-daemon --merge-logs -p /opt/bitnami/ghost/tmp/pids/ghost.pid /opt/bitnami/ghost/index.js
+exec gosu ${USER} /opt/bitnami/ghost/node_modules/pm2/bin/pm2 start --merge-logs --no-daemon \
+  -p /opt/bitnami/ghost/tmp/pids/ghost.pid \
+  -l /opt/bitnami/ghost/logs/ghost.log \
+  /opt/bitnami/ghost/index.js

--- a/0/rootfs/run.sh
+++ b/0/rootfs/run.sh
@@ -7,4 +7,4 @@ USER=ghost
 export NODE_ENV=production
 
 info "Starting ghost..."
-exec gosu ${USER} /opt/bitnami/ghost/node_modules/pm2/bin/pm2 start --no-daemon --merge-logs /opt/bitnami/ghost/index.js
+exec gosu ${USER} /opt/bitnami/ghost/node_modules/pm2/bin/pm2 start --no-daemon --merge-logs -p /opt/bitnami/ghost/tmp/pids/ghost.pid /opt/bitnami/ghost/index.js

--- a/0/rootfs/run.sh
+++ b/0/rootfs/run.sh
@@ -6,6 +6,9 @@ USER=ghost
 
 export NODE_ENV=production
 
+# drupal initialization leaves a running pm2 instance
+gosu ${USER} /opt/bitnami/ghost/node_modules/pm2/bin/pm2 kill
+
 info "Starting ghost..."
 exec gosu ${USER} /opt/bitnami/ghost/node_modules/pm2/bin/pm2 start --merge-logs --no-daemon \
   -p /opt/bitnami/ghost/tmp/pids/ghost.pid \


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

- The `ghost.pid` file path has been added to the `pm2 start` command to resolve the issue.
- The `pm2 start` command has been brought to parity with the command executed by `nami start`. 
- Kill the pm2 daemon left from the `nami initialize ghost` command

**Benefits**

<!-- What benefits will be realized by the code change? -->

Fixes issues encountered while using the image in the BTS (internal) tests.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

- N.A. -