### PR TITLE
Set secure connection as bool value (instead of string)

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libghost.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libghost.sh
@@ -292,7 +292,7 @@ EOF
                 ghost_conf_set "mail.transport" "SMTP"
                 ghost_conf_set "mail.options.host" "$GHOST_SMTP_HOST"
                 ghost_conf_set "mail.options.port" "$GHOST_SMTP_PORT_NUMBER" "int"
-                ghost_conf_set "mail.options.secureConnection" "$([[ "$GHOST_SMTP_PROTOCOL" = "ssl" || "$GHOST_SMTP_PROTOCOL" = "tls" ]] && echo "true" || echo "false")"
+                ghost_conf_set "mail.options.secureConnection" "$([[ "$GHOST_SMTP_PROTOCOL" = "ssl" || "$GHOST_SMTP_PROTOCOL" = "tls" ]] && echo "true" || echo "false")" "bool"
                 ghost_conf_set "mail.options.auth.user" "$GHOST_SMTP_USER"
                 ghost_conf_set "mail.options.auth.pass" "$GHOST_SMTP_PASSWORD"
             fi

--- a/4/debian-10/rootfs/opt/bitnami/scripts/libghost.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libghost.sh
@@ -292,7 +292,7 @@ EOF
                 ghost_conf_set "mail.transport" "SMTP"
                 ghost_conf_set "mail.options.host" "$GHOST_SMTP_HOST"
                 ghost_conf_set "mail.options.port" "$GHOST_SMTP_PORT_NUMBER" "int"
-                ghost_conf_set "mail.options.secureConnection" "$([[ "$GHOST_SMTP_PROTOCOL" = "ssl" || "$GHOST_SMTP_PROTOCOL" = "tls" ]] && echo "true" || echo "false")"
+                ghost_conf_set "mail.options.secureConnection" "$([[ "$GHOST_SMTP_PROTOCOL" = "ssl" || "$GHOST_SMTP_PROTOCOL" = "tls" ]] && echo "true" || echo "false")" "bool"
                 ghost_conf_set "mail.options.auth.user" "$GHOST_SMTP_USER"
                 ghost_conf_set "mail.options.auth.pass" "$GHOST_SMTP_PASSWORD"
             fi


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
This change improves how the image handles new setups for already secure connection for mailer. Currently the value is set as a string `"false"` instead of a bool and it causes SSL error as non-empty string is considered truthy by JavaScript.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Initial installations will properly handle secure connections to a mailer.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None, as far as I can tell.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None - I found the issue today and decided to fix ASAP.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
