### PR TITLE
Support for enabling SSL on ghost database with or without SSL CA file

### DIFF
--- a/4/debian-10/rootfs/opt/bitnami/scripts/ghost-env.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/ghost-env.sh
@@ -42,6 +42,8 @@ ghost_env_vars=(
     GHOST_DATABASE_NAME
     GHOST_DATABASE_USER
     GHOST_DATABASE_PASSWORD
+    GHOST_DATABASE_ENABLE_SSL
+    GHOST_DATABASE_SSL_CA_FILE
     BLOG_TITLE
     SMTP_HOST
     SMTP_PORT
@@ -125,5 +127,7 @@ GHOST_DATABASE_USER="${GHOST_DATABASE_USER:-"${MARIADB_DATABASE_USER:-}"}"
 export GHOST_DATABASE_USER="${GHOST_DATABASE_USER:-bn_ghost}" # only used during the first initialization
 GHOST_DATABASE_PASSWORD="${GHOST_DATABASE_PASSWORD:-"${MARIADB_DATABASE_PASSWORD:-}"}"
 export GHOST_DATABASE_PASSWORD="${GHOST_DATABASE_PASSWORD:-}" # only used during the first initialization
+export GHOST_DATABASE_ENABLE_SSL="${GHOST_DATABASE_ENABLE_SSL:-no}" # only used during the first initialization
+export GHOST_DATABASE_SSL_CA_FILE="${GHOST_DATABASE_SSL_CA_FILE:-}" # only used during the first initialization
 
 # Custom environment variables may be defined below

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ Available environment variables:
 - `GHOST_DATABASE_NAME`: Database name that Ghost will use to connect with the database. Default: **bitnami_ghost**
 - `GHOST_DATABASE_USER`: Database user that Ghost will use to connect with the database. Default: **bn_ghost**
 - `GHOST_DATABASE_PASSWORD`: Database password that Ghost will use to connect with the database. No default.
+- `GHOST_DATABASE_ENABLE_SSL`: It can be used to enable database SSL configuration. Default: **no**
+- `GHOST_DATABASE_SSL_CA_FILE`: Path to the database SSL CA file. No default.
 - `ALLOW_EMPTY_PASSWORD`: It can be used to allow blank passwords. Default: **no**
 
 ##### Create a database for Ghost using mysql-client


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Enables SSL database connection in Ghost Configuration.

Adding the following settings:
- `GHOST_DATABASE_ENABLE_SSL`: It can be used to enable database SSL configuration. Default: **no**
- `GHOST_DATABASE_SSL_CA_FILE`: Path to the database SSL CA file. No default.

**Benefits**

SSL connection configuration support to mysql database for Ghost, covering the 2 examples cases of the official documentation **boolean** and **json**: https://ghost.org/docs/config/#ssl-1

```
"ssl": true
```

```
"ssl": {
    "enabled": true,
    "ca": "xxxx"
}
```

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

- Tested in Azure database with SSL connection.
- Related to PR(closed): https://github.com/bitnami/bitnami-docker-ghost/pull/116
